### PR TITLE
Add env var USERNAME to deprovision command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ export KUBECONFIG=./auth/kubeconfig
 oc status
 ```
 
-Deprovision the cluster by running `make deprovision`.
+Deprovision the cluster by running `make deprovision USERNAME=<your username>`.
 
 # Tips & tricks
 * Mount your own version of openshift-ansible with `make ANSIBLE_REPO=local/path/to/openshift-ansible`


### PR DESCRIPTION
Or else it will turns into a deprovison command with empty INSTANCE_PREFIX

```
sudo podman run --privileged --rm -v /root/1213/openshift-40-centos:/output:z --user 0 \
   \
  -v /root/1213/openshift-40-centos/injected:/usr/share/ansible/openshift-ansible/inventory/dynamic/injected:z \
  -e INSTANCE_PREFIX="" -e OPTS="-vvv" \
  -ti quay.io/vrutkovs/openshift-40-centos \
  deprovision
```